### PR TITLE
Update collection transformer to accept Illuminate\Support\Collection collections

### DIFF
--- a/src/Translator/Transformers/CollectionTransformer.php
+++ b/src/Translator/Transformers/CollectionTransformer.php
@@ -2,7 +2,7 @@
 namespace Tectonic\LaravelLocalisation\Translator\Transformers;
 
 use Tectonic\LaravelLocalisation\Translator\Translated\Collection as TranslatedCollection;
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Collection;
 use Tectonic\Localisation\Contracts\Transformer;
 use Tectonic\Localisation\Translator\Transformers\Transformer as BaseTransformer;
 


### PR DESCRIPTION
In recent versions of Laravel using `pluck` on a collection returns an instance
of `Illuminate\Support\Collection`. In the past the collection type was preserved, not any longer...

```
>>> $collection = new Illuminate\Database\Eloquent\Collection;
=> Illuminate\Database\Eloquent\Collection {#2198
     all: [],
   }
>>> $collection->pluck('id');
=> Illuminate\Support\Collection {#2194
     all: [],
   }
```

It would help if `CollectionTransformer` worked with `Illuminate\Support\Collection` collections.
