### PR TITLE
Bugfix - Add support for translating deep model relationships with one missing relation

### DIFF
--- a/src/Translator/Transformers/CollectionTransformer.php
+++ b/src/Translator/Transformers/CollectionTransformer.php
@@ -130,7 +130,7 @@ class CollectionTransformer extends BaseTransformer implements Transformer
                             ->groupBy(fn ($item) => $this->groupByKey($item))
                     );
                 }
-            } else {
+            } elseif ($relation) {
                 $relationTranslations->push($translations->get($this->groupByKey($relation)));
                 if (array_filter($relation->getRelations())) {
                     $relationTranslations = $relationTranslations->merge(

--- a/src/Translator/Transformers/CollectionTransformer.php
+++ b/src/Translator/Transformers/CollectionTransformer.php
@@ -121,6 +121,7 @@ class CollectionTransformer extends BaseTransformer implements Transformer
 
     protected function parseRelationsTranslations(array $relations, Collection $translations): Collection
     {
+
         $relationTranslations = collect();
         foreach ($relations as $relation) {
             if ($relation instanceof Collection) {
@@ -130,9 +131,16 @@ class CollectionTransformer extends BaseTransformer implements Transformer
                             ->groupBy(fn ($item) => $this->groupByKey($item))
                     );
                 }
-            } elseif ($relation) {
+            } else {
                 $relationTranslations->push($translations->get($this->groupByKey($relation)));
+
+                if ($relation === null) {
+                    dd('Relation is null', $relation, $translations);
+                }
+
                 if (array_filter($relation->getRelations())) {
+                    //dd($relation);
+
                     $relationTranslations = $relationTranslations->merge(
                         $this->parseRelationsTranslations($relation->getRelations(), $translations)
                     );

--- a/src/Translator/Transformers/CollectionTransformer.php
+++ b/src/Translator/Transformers/CollectionTransformer.php
@@ -131,18 +131,13 @@ class CollectionTransformer extends BaseTransformer implements Transformer
                             ->groupBy(fn ($item) => $this->groupByKey($item))
                     );
                 }
-            } else {
+            } elseif(!is_null($relation)) {
                 $relationTranslations->push($translations->get($this->groupByKey($relation)));
-
-                if ($relation === null) {
-                    dd('Relation is null', $relation, $translations);
-                }
-
-                if (array_filter($relation->getRelations())) {
-                    //dd($relation);
+ 
+                if ($deepRelations = array_filter($relation->getRelations())) {
 
                     $relationTranslations = $relationTranslations->merge(
-                        $this->parseRelationsTranslations($relation->getRelations(), $translations)
+                        $this->parseRelationsTranslations($deepRelations, $translations)
                     );
                 }
             }

--- a/tests/EndToEndTest.php
+++ b/tests/EndToEndTest.php
@@ -93,11 +93,7 @@ class EndToEndTest extends AcceptanceTestCase
     public function testTranslationsForCollectionDeepRelationships()
     {
         $category = Category::with(['content', 'content.links', 'content.author', 'content.author.posts'])->get();
-
-        Post::all()->each(function ($post) {
-            $post->delete();
-        });
-        $translated = Translator::translate($category->load())->first();
+        $translated = Translator::translate($category)->first();
 
         $this->assertCount(2, $translated->content);
         $this->assertCount(2, $translated->content[0]->links);
@@ -116,7 +112,7 @@ class EndToEndTest extends AcceptanceTestCase
 
         $translated = Translator::translate($category);
 
-        $this->assertCount(3, $translated->content);
+        $this->assertCount(4, $translated->content);
         $this->assertCount(2, $translated->content[0]->links);
         $this->assertEquals('This is what we shall do', $translated->content[0]->trans('en_GB', 'title'));
         $this->assertEquals('This is a link', $translated->content[0]->links[0]->trans('en_GB', 'title'));
@@ -126,35 +122,17 @@ class EndToEndTest extends AcceptanceTestCase
 
     public function testTranslationsForModelDeepRelationshipsWithMissingRelation()
     {
-        $reviewer = new Reviewer;
+        $links = Link::with(['content', 'content.links.reviewer', 'content.author'])->get();
+        $translated = Translator::translate($links);
 
-        Link::find(2)->reviewer()->save($reviewer);
-
-        $coll = Author::with([
-                                 'content',
-//             'content.category',
-                                 'content.links',
-                                 'content.links.reviewer',
-                                 'content.links.content'
-
-                             ])->paginate(1);
-
-        dd($coll);
-
-        Translator::translate($coll);
-//        $collection = Post::with(['category', 'category.content', 'category.content.links', 'category.content.author'])->paginate(1);
-//
-//        dd($collection);
-//        $translated = Translator::translate($collection);
-
-//        dd($translated->getRelations());
-
-//        $this->assertCount(3, $translated->content);
-//        $this->assertCount(2, $translated->content[0]->links);
-//        $this->assertEquals('This is what we shall do', $translated->content[0]->trans('en_GB', 'title'));
-//        $this->assertEquals('This is a link', $translated->content[0]->links[0]->trans('en_GB', 'title'));
-//        $this->assertEquals('Author 2 summary', $translated->content[0]->author->trans('en_GB', 'summary'));
-//        $this->assertEquals('This is a title 3', $translated->content[0]->author->posts[0]->trans('en_GB', 'title'));
+        $this->assertCount(11, $translated);
+        $link = $translated->first();
+        $this->assertCount(2, $link->content->links);
+        $this->assertEquals('This is a link', $link->trans('en_GB', 'title'));
+        $this->assertEquals('This is what we shall do', $link->content->trans('en_GB', 'title'));
+        $this->assertEquals('This is a link',$link->content->links[0]->trans('en_GB', 'title'));
+        $this->assertEquals('Author 1 summary', $link->content->author->trans('en_GB', 'summary'));
+        $this->assertNull($link->content->author->posts[0]->trans('en_GB', 'title'));
     }
 
     /**
@@ -198,6 +176,7 @@ class EndToEndTest extends AcceptanceTestCase
         $this->author2->content()->save($this->content3 = $this->category2->content()->save(new Content));
         $this->author2->content()->save($this->content4 = $this->category2->content()->save(new Content));
         $this->author2->content()->save($this->content5 = $this->category2->content()->save(new Content));
+        $this->content6 = $this->category2->content()->save(new Content);
     }
 
     /**
@@ -215,6 +194,7 @@ class EndToEndTest extends AcceptanceTestCase
         $this->content4->links()->save(new Link);
         $this->content5->links()->save(new Link);
         $this->content5->links()->save(new Link);
+        $this->content6->links()->save(new Link);
     }
 
     /**

--- a/tests/Fixtures/Migrations/2014_10_21_45367_create_content_table.php
+++ b/tests/Fixtures/Migrations/2014_10_21_45367_create_content_table.php
@@ -15,7 +15,7 @@ class CreateContentTable extends Migration {
 		Schema::create('content', function(Blueprint $table)
         {
             $table->increments('id');
-            $table->integer('category_id')->index();
+            $table->integer('category_id')->index()->nullable();
             $table->integer('author_id')->nullable()->index();
             $table->timestamps();
 

--- a/tests/Fixtures/Migrations/2023_02_16_45368_create_reviewers_table.php
+++ b/tests/Fixtures/Migrations/2023_02_16_45368_create_reviewers_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateReviewersTable extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::create('reviewers', function(Blueprint $table)
+        {
+            $table->increments('id');
+            $table->integer('link_id')->index();
+            $table->timestamps();
+
+            $table->foreign('link_id')->references('id')->on('links');
+        });
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::drop('reviewers');
+	}
+
+}

--- a/tests/Fixtures/Models/Reviewer.php
+++ b/tests/Fixtures/Models/Reviewer.php
@@ -5,21 +5,17 @@ use Tectonic\LaravelLocalisation\Database\TranslationRetriever;
 use Tectonic\Localisation\Contracts\Translatable;
 use Tectonic\Localisation\Translator\Translations;
 
-class Link extends \Eloquent implements Translatable
+class Reviewer extends \Eloquent implements Translatable
 {
     use Translations;
     use TranslationRetriever;
 
-	public function content()
-    {
-        return $this->belongsTo(Content::class);
-    }
+    public $table = 'reviewers';
 
-    public function reviewer()
+    public function link()
     {
-        return $this->hasOne(Reviewer::class);
+        return $this->belongsTo(Link::class);
     }
-
 
     /**
      * Returns an array of the field names that can be used for translations.


### PR DESCRIPTION
This pull request improves support for translating deep model relationships, even when a nested relation is null.

Previously, the package would encounter an error when translating a deep model relationship with a null nested relation.

With the new implementation, the 'parseRelationsTranslations($relations)' when the method runs recursively and checks if a deep relation is passed with a null nested relation. If so, the method skips the null relation and continues parsing the translation for the remaining nested relationships. 

This ensures that the translation process can proceed smoothly even if one of the intermediate relations is null.