### PR TITLE
Change singletons to scoped for Octane

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Install via composer:
 
     composer require tectonic/laravel-localisation
     
+Publish the configuration
+
+```shell
+php artisan vendor:publish --provider="Tectonic\LaravelLocalisation\ServiceProvider"
+```
 ## Documentation
 
 You can view the rest of the documentation here: (https://github.com/tectonic/laravel-localisation/wiki)

--- a/config/localisation.php
+++ b/config/localisation.php
@@ -4,5 +4,12 @@ return [
     /**
      * Define the model you wish to use for any translation features.
      */
-    'model' => \Tectonic\LaravelLocalisation\Database\Translation::class
+    'model' => \Tectonic\LaravelLocalisation\Database\Translation::class,
+
+    /**
+     * Define your custom transformers that will be used to transform the data.
+     */
+    'transformers' => [
+        //
+    ]
 ];

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -76,11 +76,15 @@ class ServiceProvider extends LaravelServiceProvider
     {
         $this->app->scoped('localisation.translator', function($app) {
             $translatorEngine = new Engine;
-
+            
             $translatorEngine->registerTransformer(
                 $app->make(ModelTransformer::class),
                 $app->make(CollectionTransformer::class),
-                $app->make(PaginationTransformer::class)
+                $app->make(PaginationTransformer::class),
+                ...array_map(
+                    fn ($transformer) => $app->make($transformer),
+                    $app['config']->get('localisation.transformers', [])
+                )
             );
 
             return $translatorEngine;

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -34,7 +34,7 @@ class ServiceProvider extends LaravelServiceProvider
      */
     private function registerTranslationRepository()
     {
-        $this->app->singleton(TranslationRepository::class, function($app) {
+        $this->app->scoped(TranslationRepository::class, function($app) {
             $model = $app['config']->get('localisation.model');
 
             return new EloquentTranslationRepository(new $model);
@@ -47,7 +47,7 @@ class ServiceProvider extends LaravelServiceProvider
      */
     private function registerModelTransformer()
     {
-        $this->app->singleton(ModelTransformer::class, function($app) {
+        $this->app->scoped(ModelTransformer::class, function($app) {
             $modelTransformer = new ModelTransformer;
             $modelTransformer->setTranslationRepository($app->make(TranslationRepository::class));
 
@@ -61,7 +61,7 @@ class ServiceProvider extends LaravelServiceProvider
      */
     private function registerCollectionTransformer()
     {
-        $this->app->singleton(CollectionTransformer::class, function($app) {
+        $this->app->scoped(CollectionTransformer::class, function($app) {
             $collectionTransformer = new CollectionTransformer;
             $collectionTransformer->setTranslationRepository($app->make(TranslationRepository::class));
 
@@ -74,7 +74,7 @@ class ServiceProvider extends LaravelServiceProvider
      */
     private function registerTranslator()
     {
-        $this->app->singleton('localisation.translator', function($app) {
+        $this->app->scoped('localisation.translator', function($app) {
             $translatorEngine = new Engine;
 
             $translatorEngine->registerTransformer(


### PR DESCRIPTION
There are some issues when this package is used with Laravel Octane with saving and retrieval of new translations.
Most of the times the saved translations wont take effect until the octane worker shuts down. I am not fully aware of why this is happening, but changing all the services (it really needs **all** the services) from `singleton` to `scoped` resolves this issue.

This wont affect anything in non-octane projects.