### PR TITLE
Configuration based transformer registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Install via composer:
 
     composer require tectonic/laravel-localisation
     
+Publish the configuration
+
+```shell
+php artisan vendor:publish --provider="Tectonic\LaravelLocalisation\ServiceProvider"
+```
 ## Documentation
 
 You can view the rest of the documentation here: (https://github.com/tectonic/laravel-localisation/wiki)

--- a/config/localisation.php
+++ b/config/localisation.php
@@ -4,5 +4,12 @@ return [
     /**
      * Define the model you wish to use for any translation features.
      */
-    'model' => \Tectonic\LaravelLocalisation\Database\Translation::class
+    'model' => \Tectonic\LaravelLocalisation\Database\Translation::class,
+
+    /**
+     * Define your custom transformers that will be used to transform the data.
+     */
+    'transformers' => [
+        //
+    ]
 ];

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -76,11 +76,15 @@ class ServiceProvider extends LaravelServiceProvider
     {
         $this->app->scoped('localisation.translator', function($app) {
             $translatorEngine = new Engine;
-
+            
             $translatorEngine->registerTransformer(
                 $app->make(ModelTransformer::class),
                 $app->make(CollectionTransformer::class),
-                $app->make(PaginationTransformer::class)
+                $app->make(PaginationTransformer::class),
+                ...array_map(
+                    fn ($transformer) => $app->make($transformer),
+                    $app['config']->get('localisation.transformers', [])
+                )
             );
 
             return $translatorEngine;


### PR DESCRIPTION
This PR tackles one other issue when the package is used with octane.
In order to register custom _transformers_ we had to add them during `boot()` on a service provider. This was problematic with scoped services as the boot would run once per octane worker while the service would be fresh for each request.

In order to handle this I added a new configuration array `transformers` in which we can place our custom transformers to be registered in every new instance of the localisation engine.