### PR TITLE
Add Laravel 12 and 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
 	],
 	"require": {
 		"php": "^7.4|^8.0|^8.2",
-		"illuminate/support": "^8.0|^9.0|^10.0|^11.0",
-		"illuminate/database": "^8.0|^9.0|^10.0|^11.0",
+		"illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+		"illuminate/database": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
 		"tectonic/localisation": "^3.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
Widens illuminate/* constraints to include Laravel 12 and 13 alongside the existing supported majors.

Part of the Laravel 13 upgrade across the Force ecosystem (Trello: https://trello.com/c/vNj0ruaA).